### PR TITLE
augment check for string data for object as well

### DIFF
--- a/lib/dpush.js
+++ b/lib/dpush.js
@@ -19,7 +19,7 @@ exports.send = function (apiKey, registrationIds, message, callback) {
     }
     else if (typeof message === 'object') {
         for (var i in message) {
-            if (typeof message[i] !== 'string') {
+            if (typeof message[i] !== 'string' && typeof message[i] !== 'object') {
                 throw new Error('The message must be either a string or a JSON object with string properties.');
             }
         }


### PR DESCRIPTION
GCM allows for more than just `string` key/value pairs.

From the docs (http://developer.android.com/google/gcm/gcm.html):

The values could be any JSON object, but we recommend using strings, since the values will be converted to strings in the GCM server anyway.

This pull request augments the `string` check to also allow an object through the filter.

Thanks!
